### PR TITLE
将docker-compose文件中暴露的容器端口由8000改为8080

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     container_name: daohang
     restart: always
     ports:
-      - 8080:8000
+      - 8080:8080


### PR DESCRIPTION
容器里服务启动后监听的是8080端口。